### PR TITLE
Parse OSV results to extract vulnerable symbols

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,10 +7,38 @@ import (
 )
 
 func main() {
-	result, err := osv.QueryOSV("lodash", "4.17.20", "npm")
+	advisories, err := osv.QueryOSV("lodash", "4.17.20", "npm")
+	// advisories, err := osv.QueryOSV("golang.org/x/text", "0.3.8", "Go")
 	if err != nil {
 		fmt.Println("Failed to query OSV:", err)
 		return
 	}
-	fmt.Println("Raw OSV Response:\n", result)
+
+	for _, adv := range advisories {
+		fmt.Println("ID:", adv.ID)
+		fmt.Println("Summary:", adv.Summary)
+		fmt.Println("Details:", adv.Details)
+
+		var combinedSymbols []string
+		for _, aff := range adv.Affected {
+			for _, imp := range aff.EcosystemSpecific.Imports {
+				combinedSymbols = append(combinedSymbols, imp.Symbols...)
+			}
+		}
+
+		extractedSymbols := osv.ExtractPossibleSymbols("lodash", adv.Summary, adv.Details)
+
+		combinedSymbols = append(combinedSymbols, extractedSymbols...)
+
+		uniqueMap := make(map[string]struct{})
+		var uniqueSymbols []string
+		for _, s := range combinedSymbols {
+			if _, exists := uniqueMap[s]; !exists {
+				uniqueMap[s] = struct{}{}
+				uniqueSymbols = append(uniqueSymbols, s)
+			}
+		}
+
+		fmt.Println("Combined Symbols:", uniqueSymbols)
+	}
 }

--- a/osv/parser.go
+++ b/osv/parser.go
@@ -1,0 +1,89 @@
+package osv
+
+import (
+	"regexp"
+	"strings"
+)
+
+var functionPattern = regexp.MustCompile(`\b[a-zA-Z_][a-zA-Z0-9_]*\s*\(\)`)
+var backtickPattern = regexp.MustCompile("`([a-zA-Z_][a-zA-Z0-9_]*)`")
+var funcWordPattern = regexp.MustCompile(`(?i)\b([a-zA-Z_][a-zA-Z0-9_]*)\b\s+function`)
+
+func ExtractMentionedSymbols(text string) []string {
+	funcMatches := functionPattern.FindAllString(text, -1)
+	tickMatches := backtickPattern.FindAllStringSubmatch(text, -1)
+	funcWordMatches := funcWordPattern.FindAllStringSubmatch(text, -1)
+
+	unique := make(map[string]struct{})
+	for _, match := range funcMatches {
+		symbol := match[:len(match)-2]
+		unique[symbol] = struct{}{}
+	}
+
+	for _, match := range tickMatches {
+		if len(match) > 1 {
+			unique[match[1]] = struct{}{}
+		}
+	}
+
+	for _, match := range funcWordMatches {
+		if len(match) > 1 {
+			unique[match[1]] = struct{}{}
+		}
+	}
+
+	var results []string
+	for s := range unique {
+		if isValidSymbol(s) && isSymbolLike(s) {
+			results = append(results, s)
+		}
+	}
+	return results
+}
+
+func isValidSymbol(symbol string) bool {
+	domains := []string{"github.com", ".com", ".io", ".rs", ".md", ".png", ".aarch64", ".x86_64", "e.g"}
+	for _, domain := range domains {
+		if strings.Contains(symbol, domain) {
+			return false
+		}
+	}
+	return true
+}
+
+func isSymbolLike(s string) bool {
+	blockedKeywords := []string{
+		".com", ".org", ".rs", ".io", ".md", ".txt", ".png", ".html", ".exe", ".zip", ".cr",
+		"http", "www.", "docs.", "lists.", "datatracker.", "main.ts", "go.mod", "core.rs",
+		"faq.", "readme", "swhkd.sock", "swhks.pid", "libraries.html", "e.g", "i.e",
+	}
+
+	lowerS := strings.ToLower(s)
+	for _, keyword := range blockedKeywords {
+		if strings.Contains(lowerS, keyword) {
+			return false
+		}
+	}
+	return true
+}
+
+func ExtractPossibleSymbols(name, summary, details string) []string {
+	text := summary + " " + details
+
+	allMatches := ExtractMentionedSymbols(text)
+
+	var validMatches []string
+	for _, match := range allMatches {
+		if isValidSymbol(match) && isSymbolLike(match) {
+			validMatches = append(validMatches, match)
+		}
+	}
+
+	for i, match := range validMatches {
+		if match == name {
+			validMatches = append(validMatches[:i], validMatches[i+1:]...)
+			break
+		}
+	}
+	return validMatches
+}

--- a/osv/types.go
+++ b/osv/types.go
@@ -1,0 +1,35 @@
+package osv
+
+type OSVRequest struct {
+	Package struct {
+		Name      string `json:"name"`
+		Ecosystem string `json:"ecosystem"`
+	} `json:"package"`
+	Version string `json:"version"`
+}
+
+type Advisory struct {
+	ID       string     `json:"id"`
+	Summary  string     `json:"summary"`
+	Details  string     `json:"details"`
+	Affected []Affected `json:"affected"`
+}
+
+type Affected struct {
+	Package           PackageInfo       `json:"package"`
+	EcosystemSpecific EcosystemSpecific `json:"ecosystem_specific"`
+}
+
+type PackageInfo struct {
+	Name      string `json:"name"`
+	Ecosystem string `json:"ecosystem"`
+}
+
+type EcosystemSpecific struct {
+	Imports []Import `json:"imports"`
+}
+
+type Import struct {
+	Path    string   `json:"path"`
+	Symbols []string `json:"symbols"`
+}


### PR DESCRIPTION
Added logic to extract symbols/functions that are likely affected in a given OSV advisory. It combines two sources:
- Directly reported symbols (from affected[].ecosystem_specific.imports[].symbols)
- Heuristically extracted symbols from the advisory's summary and details fields using:
-- Function call patterns (e.g. toNumber())
-- Inline backtick references (e.g. `trim`)
-- Descriptive phrases (e.g. “the foo function”)

To avoid false positives, the extraction filters out:
- Static asset references (e.g. .png, .md, .rs)
- Package names
- Keywords commonly seen in documentation or URLs

The final set of symbols is de-duplicated and returned as a unified list, enabling the tool to use both confirmed and inferred vulnerable symbols.